### PR TITLE
Fix because of spatstat changes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,7 @@ Imports:
     graphics,
     grDevices,
     spatstat,
+    spatstat.geom,
     stats
 Suggests: splancs
 Description: Edge-corrected kernel density estimation and binary kernel

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: spatialkernel
-Version: 0.4-24
+Version: 0.4-25
 Date: 2020-02-21
 Title: Non-Parametric Estimation of Spatial Segregation in a
         Multivariate Point Process
@@ -30,7 +30,6 @@ Depends: R (>= 2.10)
 Imports:
     graphics,
     grDevices,
-    spatstat,
     spatstat.geom,
     stats
 Suggests: splancs

--- a/R/spseg.R
+++ b/R/spseg.R
@@ -203,7 +203,7 @@ spseg <- function(pts, ...){
 ##' @rdname spseg
 ##' @export
 spseg.ppp = function(pts, h, opt, ...){
-    pw = as.data.frame(spatstat::as.polygonal(pts$win))
+    pw = as.data.frame(spatstat.geom::as.polygonal(pts$win))
     if(ncol(pw)>2){
         stop("spseg can only handle simple ring windows")
     }

--- a/R/spseg.R
+++ b/R/spseg.R
@@ -210,7 +210,7 @@ spseg.ppp = function(pts, h, opt, ...){
     
     xypoly = as.matrix(pw)
     xypts = cbind(pts$x, pts$y)
-    m = spatstat::marks(pts)
+    m = spatstat.geom::marks(pts)
     # test if only one mark
     m = as.character(m)
     spseg.matrix(xypts, m, h=h, opt=opt, poly=xypoly, ...)


### PR DESCRIPTION
spatstat moved all their code into sub-packages like spatstat.core and spatstat.geom.

spatialkernel calls `marks` and `as.polygonal`, and these are now in `spatstat.geom`.

It passes R CMD check cleanly, check --as-cran reports:

```
CRAN repository db overrides:
  X-CRAN-Comment: Archived on 2020-02-24 as check problems were not
    corrected in time.

  Simple fix needed to issues reported by LTO.
```

No idea what CRAN's problems were then...
